### PR TITLE
Fix broken calendar link for tidyverse event

### DIFF
--- a/_posts/2017-02-16-Tidyverse.md
+++ b/_posts/2017-02-16-Tidyverse.md
@@ -1,5 +1,5 @@
 ---
-title: From Messy to Tidy: Intro to Data Carpentry in R
+title: From Messy to Tidy - Intro to Data Carpentry in R
 text: Eric Leung and Ted Laderas talk about getting your data into R and manipulating it using the tidyverse.
 location: BICC124
 link: https://github.com/daniellecrobinson/OHSU-Code-Club/issues/17


### PR DESCRIPTION
I think this will fix it. YAML is probably colon sensitive.

Closes #39 