### PR TITLE
Fix non-existing github repo link to OHSU-Code-Club repo address

### DIFF
--- a/_includes/events.html
+++ b/_includes/events.html
@@ -43,10 +43,10 @@
             <div class="col-lg-12">
             {% endif %}
               <h3 class="section-heading eventInstructions">Want to be notified of our upcoming events?</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">Head over to <a href="{{ site.github.owner_url }}/Events">GitHub</a> and watch our repository, like this:</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">Head over to <a href="{{ site.github.owner_url }}/OHSU-Code-Club">GitHub</a> and watch our repository, like this:</h3>
               <figure>
                 <img src="https://help.github.com/assets/images/help/notifications/watcher_picker.gif"></img>
-                <figcaption>Look in the top right-hand corner of <a href="{{ site.github.owner_url }}/Events">our repo</a>, and click 'Watching.' <br>You can undo this at any time in the same place.</figcaption>
+                <figcaption>Look in the top right-hand corner of <a href="{{ site.github.owner_url }}/OHSU-Code-Club">our repo</a>, and click 'Watching.' <br>You can undo this at any time in the same place.</figcaption>
               </figure>
             </div>
             {% if site.calendar_on %}


### PR DESCRIPTION
Hello!

I found that the link to the OHSU-Code-Club github repository was broken. The original script would point to www.github.com/daniellecrobinson/Events which doesn't exist. This patch fixes it to be www.github.com/daniellecrobinson/OHSU-Code-Club.

I just wanted to remind everyone that it looks like the UofTCoders (where this website was forked from) has a separate repository called `Events`, where they post only the events.